### PR TITLE
empty space added in the index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,7 +698,7 @@
 
                 <div class="footer-links">
                   <h4>Contact Us</h4>
-                    <strong>Email:</strong><a href="mailto:<nowiki>scodein@outlook.com?subject=Query link">scodein@outlook.com</a><br>
+                    <strong>Email: </strong><a href="mailto:<nowiki>scodein@outlook.com?subject=Query link">scodein@outlook.com</a><br>
                   </p>
                 </div>
 


### PR DESCRIPTION
# Description

As requested in #45 I added the empty space after the "Email:" label in the footer.

Fixes #45

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Opening the updated HTML with Chrome Browser.


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
