### PR TITLE
fix: clear input value on button click

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -196,9 +196,11 @@
   // Ensures valid email is supplied
   $(".subscribe").click(function () {
     if (/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/.test(document.getElementById('email').value)) {
-      document.getElementById('email').value = "Thank you for subscribing to our newsletters."
+      document.getElementById('email').value = ""
+      document.getElementById('email').placeholder = "Thank you for subscribing to our newsletters."
     } else {
-      document.getElementById('email').value = "Please enter a valid email address."
+      document.getElementById('email').value = ""
+      document.getElementById('email').placeholder = "Please enter a valid email address."
     }
   });
 })(jQuery);


### PR DESCRIPTION
# Description

When a user clicks the subscribe button, this code sets the input value to an empty string and the input placeholder value is updated to the success / fail message.

This means when the user tries to add another email, the previous address has been deleted and they can type another address without it including the previous address.

Fixes #114 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Enter valid email address, click subscribe button, click input box and previous email address value is no longer present
- Enter invalid email address, click subscribe button, click input box and previous email address value is no longer present

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
