### PR TITLE
fixed color contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
           <h2>STUDENT CODE-IN</h2>
           <h5><br>A Step Towards<span> Open Source!</span></h5>
           <div>
-            <a href="#about" class="btn-get-started scrollto">Get Started</a>
+            <a href="#about" class="btn-get-started scrollto" style="background-color: #1f819b ;">Get Started</a>
           </div>
         </div>
 
@@ -639,7 +639,7 @@
           </div>
         </div>
         <div class="center-it">
-          <a class="btn btn-primary btn-lg sp-btn"
+          <a class="btn btn-primary btn-lg sp-btn" style="background-color: #0078d7 ;"
             href="https://docs.google.com/forms/d/1EvhKxub2kroqk4s8KlBpmLwXE4vTc3-wy5Xa8qK5YTM/edit"
             role="button">Sponsor
             Us</a>
@@ -846,7 +846,7 @@
 
         <div class="footer-links">
           <h4>Contact Us</h4>
-          <strong>Email: </strong><a
+          <strong>Email: </strong><a style="color: #1b73cd;"
             href="mailto:<nowiki>scodein@outlook.com?subject=Query link">scodein@outlook.com</a><br>
           </p>
         </div>


### PR DESCRIPTION
# Description

Fixed the color ratio of two buttons and a link ( the " get started " & " sponsor us " btn and the " mailto: " link).

Fixes the issue Background and foreground colors do not have a sufficient contrast ratio( #112 )

## Type of change
- [ ] This change requires a documentation update
